### PR TITLE
Fix msc_clzll

### DIFF
--- a/src/Slimfmt.cpp
+++ b/src/Slimfmt.cpp
@@ -60,16 +60,16 @@
 # endif // __clang__
 
 static inline int msc_clzll(std::uint64_t V) {
+  assert(V != 0 && "Invalid clzll input!");
   unsigned long Out = 0;
 #ifdef _WIN64
   _BitScanReverse64(&Out, V);
 #else // _WIN64
   if (_BitScanReverse(&Out, std::uint32_t(V >> 32)))
-    return 63 ^ int(Out + 32);
+    return 63 - int(Out + 32);
   _BitScanReverse(&Out, std::uint32_t(V));
 #endif // _WIN64
-  assert(V != 0 && "Invalid clzll input!");
-  return int(Out);
+  return 63 - int(Out);
 }
 
 # define SLIMFMT_CLZLL(x) ::msc_clzll(x)

--- a/src/Slimfmt.cpp
+++ b/src/Slimfmt.cpp
@@ -62,11 +62,11 @@
 static inline int msc_clzll(std::uint64_t V) {
   unsigned long Out = 0;
 #ifdef _WIN64
-  _BitScanForward64(&Out, V);
+  _BitScanReverse64(&Out, V);
 #else // _WIN64
-  if (_BitScanForward(&Out, std::uint32_t(V >> 32)))
+  if (_BitScanReverse(&Out, std::uint32_t(V >> 32)))
     return 63 ^ int(Out + 32);
-  _BitScanForward(&Out, std::uint32_t(V));
+  _BitScanReverse(&Out, std::uint32_t(V));
 #endif // _WIN64
   assert(V != 0 && "Invalid clzll input!");
   return int(Out);


### PR DESCRIPTION
I noticed msc_clzll is functioning as a ctz at the moment instead of a clz. I've made the same change as this PR in my little formatter https://github.com/jeremy-rifkin/microfmt/commit/981148a2e5cad09e4ed7476119ad9ee18fe8ed6f and found it to work as expected on x86 and x64.